### PR TITLE
Add support for Rupture media queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Your project's build file also needs to enable sbt-web plugins. For example with
 
     lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
-The compiler allows some of the same options to be specified as the (stylus CLI itself)[http://learnboost.github.io/stylus/docs/executable.html].
+The compiler allows some of the same options to be specified as the [stylus CLI itself](http://learnboost.github.io/stylus/docs/executable.html).
 Here are the options:
 
 Option              | Description
 --------------------|------------
 compress            | Compress output by removing some whitespace.
 useNib              | Adds nib dependency.
-useRupture          | Adds rupture dependency for media queries.
+useRupture          | Adds [rupture](http://jenius.github.io/rupture/)  dependency for media queries.
 
 ## Compression
 
@@ -58,7 +58,7 @@ div {
 
 ## Use Rupture
 
-Enable (rupture)[http://jenius.github.io/rupture/] to enable simple media queries in Stylus.
+Enable [rupture](http://jenius.github.io/rupture/) to enable simple media queries in Stylus.
 
 ```scala
 StylusKeys.useRupture in Assets := true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ Here are the options:
 Option              | Description
 --------------------|------------
 compress            | Compress output by removing some whitespaces.
-useNib              | Adds nib dependency
+useNib              | Adds nib dependency.
+useRupture          | Adds (rupture)[http://jenius.github.io/rupture/] dependency for media queries,
+
+## Compression
+
+The following sbt code illustrates how compression can be enabled:
+
+```scala
+StylusKeys.compress in Assets := true
+```
 
 ## Use Nib:
 
@@ -47,13 +56,32 @@ div {
 }
 ```
 
-
-## Compression
-
-The following sbt code illustrates how compression can be enabled:
-
+## Use Rupture
 ```scala
-StylusKeys.compress in Assets := true
+StylusKeys.useRupture in Assets := true
+```
+
+```stylus
+@import 'rupture'
+
+.whatever
+  color: red
+
++below(480px)
+  .whatever
+    color: green
+
+```
+will compile to:
+```css
+.whatever {
+  color: #f00;
+}
+@media only screen and (max-width: 480px) {
+  .whatever {
+    color: #008000;
+  }
+}
 ```
 
 ## File filters

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Here are the options:
 
 Option              | Description
 --------------------|------------
-compress            | Compress output by removing some whitespaces.
+compress            | Compress output by removing some whitespace.
 useNib              | Adds nib dependency.
-useRupture          | Adds (rupture)[http://jenius.github.io/rupture/] dependency for media queries,
+useRupture          | Adds rupture dependency for media queries.
 
 ## Compression
 
@@ -57,6 +57,9 @@ div {
 ```
 
 ## Use Rupture
+
+Enable (rupture)[http://jenius.github.io/rupture/] to enable simple media queries in Stylus.
+
 ```scala
 StylusKeys.useRupture in Assets := true
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ libraryDependencies ++= Seq(
   "org.webjars" % "mkdirp" % "0.3.5",
   "org.webjars" % "stylus" % "0.51.1",
   "org.webjars" % "stylus-nib" % "1.1.0",
+  "org.webjars" % "rupture" % "0.6.1", // stylus plugin for media queries
   "org.webjars" % "when-node" % "3.5.2-3"
 )
 

--- a/src/main/resources/stylus-shell.js
+++ b/src/main/resources/stylus-shell.js
@@ -7,6 +7,7 @@ var fs = require("fs"),
     path = require("path"),
     stylus = require("stylus"),
     nib = require("nib");
+    rupture = require("rupture");
 
 var promised = {
     mkdirp: nodefn.lift(mkdirp),
@@ -28,6 +29,7 @@ function processor(input, output) {
 
     var style = stylus(contents, options)
     if (options.useNib) style.use(nib());
+    if (options.useRupture) style.use(rupture());
 
     style.render(function (err, css) {
         if (err) {
@@ -40,7 +42,7 @@ function processor(input, output) {
         }
       });
     return result;
-    
+
   }).then(function(result) {
     return promised.mkdirp(path.dirname(output)).yield(result);
 
@@ -81,5 +83,3 @@ function parseError(input, contents, err) {
     source: input
   };
 }
-
-

--- a/src/main/scala/com/typesafe/sbt/stylus/SbtStylus.scala
+++ b/src/main/scala/com/typesafe/sbt/stylus/SbtStylus.scala
@@ -13,6 +13,7 @@ object Import {
 
     val compress = SettingKey[Boolean]("stylus-compress", "Compress output by removing some whitespaces.")
     val useNib = SettingKey[Boolean]("stylus-nib", "Use stylus nib.")
+    val useRupture = SettingKey[Boolean]("stylus-rupture", "Use rupture media queries.")
   }
 
 }
@@ -36,13 +37,15 @@ object SbtStylus extends AutoPlugin {
 
     jsOptions := JsObject(
       "compress" -> JsBoolean(compress.value),
-      "useNib" -> JsBoolean(useNib.value)
+      "useNib" -> JsBoolean(useNib.value),
+      "useRupture" -> JsBoolean(useRupture.value)
     ).toString()
   )
 
   override def projectSettings = Seq(
     compress := false,
-    useNib := false
+    useNib := false,
+    useRupture := false
 
   ) ++ inTask(stylus)(
     SbtJsTask.jsTaskSpecificUnscopedSettings ++

--- a/src/sbt-test/sbt-stylus/normal/build.sbt
+++ b/src/sbt-test/sbt-stylus/normal/build.sbt
@@ -10,6 +10,21 @@ checkMainCssContents := {
                            |  -webkit-box-shadow: 2px 2px 2px #000;
                            |  box-shadow: 2px 2px 2px #000;
                            |}
+                           |.whatever {
+                           |  color: #f00;
+                           |}
+                           |@media only screen and (max-width: 480px) {
+                           |  .whatever {
+                           |    color: #008000;
+                           |  }
+                           |}
                            |""".stripMargin
-  if (contents != expectedContents) sys.error(s"Not what we expected: $contents")
+  if (contents != expectedContents) {
+    sys.error(s"""Not what we expected. Got:
+                 |$contents
+                 |
+                 |Expected:
+                 |$expectedContents
+                 |""".stripMargin)
+  }
 }

--- a/src/sbt-test/sbt-stylus/normal/src/main/assets/css/main.styl
+++ b/src/sbt-test/sbt-stylus/normal/src/main/assets/css/main.styl
@@ -1,6 +1,14 @@
 @import 'nib'
+@import 'rupture'
 
 body
   color white
   display flexbox
   box-shadow: 2px 2px 2px #000
+
+.whatever
+  color: red
+
++below(480px)
+  .whatever
+    color: green

--- a/src/sbt-test/sbt-stylus/normal/test
+++ b/src/sbt-test/sbt-stylus/normal/test
@@ -1,7 +1,8 @@
-# Compile a less file
+# Compile a Stylus file
 
 > set JsEngineKeys.engineType := JsEngineKeys.EngineType.Node
 > set StylusKeys.useNib in Assets := true
+> set StylusKeys.useRupture in Assets := true
 
 > assets
 $ exists target/web/public/main/css/main.css


### PR DESCRIPTION
Rupture is a really powerful and useful Stylus plugin for performing media queries. Similar to Nib, it needs to be included as a plugin lib when Stylus starts. 

Slightly off topic... one day when we have more than just two plugins to support, it would be nice to engineer a generic way to drop plugins in. For example, instead of `useRupture` or `useNib` a user can say `use("rupture")` where rupture is the name of a discoverable JS plugin lib.  
