### PR TITLE
Handle multiple extracted versions of same webjar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,11 +16,12 @@ developers += Developer(
 addSbtJsEngine("1.3.5")
 
 libraryDependencies ++= Seq(
-  "com.typesafe" % "jstranspiler" % "1.0.1",
-  "org.webjars" % "mkdirp" % "0.5.0",
-  "org.webjars" % "stylus" % "0.51.1",
-  "org.webjars" % "stylus-nib" % "1.1.0",
-  "org.webjars" % "when-node" % "3.5.2-3"
+  "org.webjars.npm" % "node-require-fallback" % "1.0.0",
+  "com.typesafe" % "jstranspiler" % "1.0.1", // sync with src/main/resources/stylus-shell.js
+  "org.webjars" % "mkdirp" % "0.5.0", // sync with src/main/resources/stylus-shell.js
+  "org.webjars" % "stylus" % "0.51.1", // sync with src/main/resources/stylus-shell.js
+  "org.webjars" % "stylus-nib" % "1.1.0", // sync with src/main/resources/stylus-shell.js
+  "org.webjars" % "when-node" % "3.5.2-3", // sync with src/main/resources/stylus-shell.js
 )
 
 // Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed

--- a/src/main/resources/stylus-shell.js
+++ b/src/main/resources/stylus-shell.js
@@ -1,12 +1,13 @@
 /*global process, require */
 
-var fs = require("fs"),
-    jst = require("jstranspiler"),
-    nodefn = require("when/node"),
-    mkdirp = require("mkdirp"),
+var requireIfExists = require('node-require-fallback'),
+    fs = require("fs"),
+    jst = requireIfExists("jstranspiler/1.0.1", "jstranspiler"), // sync with build.sbt
+    nodefn = requireIfExists("when/3.5.2-3/node", "when/node"), // sync with build.sbt
+    mkdirp = requireIfExists("mkdirp/0.5.0", "mkdirp"), // sync with build.sbt
     path = require("path"),
-    stylus = require("stylus"),
-    nib = require("nib");
+    stylus = requireIfExists("stylus/0.51.1", "stylus"), // sync with build.sbt
+    nib = requireIfExists("nib/1.1.0", "nib"); // sync with build.sbt
 
 var promised = {
     mkdirp: nodefn.lift(mkdirp),

--- a/src/sbt-test/sbt-stylus/normal/test
+++ b/src/sbt-test/sbt-stylus/normal/test
@@ -13,3 +13,9 @@ $ exists target/web/public/main/css/main.css
 > assets
 -$ exists target/web/public/main/css/main.css
 $ exists target/web/public/main/css/main.min.css
+
+$ exists project/target/node-modules/webjars/jstranspiler/src/main.js
+$ exists project/target/node-modules/webjars/mkdirp/index.js
+$ exists project/target/node-modules/webjars/stylus/index.js
+$ exists project/target/node-modules/webjars/nib/lib/nib.js
+$ exists project/target/node-modules/webjars/when/when.js


### PR DESCRIPTION
Those webjars get extracted in subfolders.

See lengthy comment in `plugins.sbt` of this pull request.

- Same as in https://github.com/sbt/sbt-coffeescript/pull/33
- https://github.com/sbt/sbt-less/pull/128
- https://github.com/sbt/sbt-jshint/pull/58
- https://github.com/sbt/sbt-mocha/pull/31

Also see
- https://github.com/webjars/webjars-locator-core/issues/141 (specially "Side note on creating subfolders")